### PR TITLE
Used deep copy when changing board state

### DIFF
--- a/Client.java
+++ b/Client.java
@@ -215,8 +215,13 @@ public class Client implements MouseListener {
 		for (int i = 0; i < 24; i++) {
 			if (triangles[i].contains(e.getX(), e.getY())) {
 				if (tri1 == -1) {
-					tri1 = i;
-					System.out.println("First triangle:" + tri1);
+				    if (board[i] != null && !board[i].isEmpty()) {
+				        tri1 = i;
+				        System.out.println("First triangle:" + tri1);
+				    } else {
+				        System.out.println("Selected triangle " + i + " is empty. Please select a triangle with pieces.");
+				    }
+
 				} else {
 					tri2 = i;
 					System.out.println("Second triangle:" + tri2);

--- a/Server.java
+++ b/Server.java
@@ -121,6 +121,8 @@ public class Server extends Thread {
 					if (i == distance) {
 						board[tri1].remove(0);
 						board[tri2].add(new Piece(PlayerColor.WHITE));
+						System.out.println("Server: After move, board state at tri1 (" + tri1 + ") has " + board[tri1].size() + " pieces.");
+						System.out.println("Server: After move, board state at tri2 (" + tri2 + ") has " + board[tri2].size() + " pieces.");
 						int count = 0;
 
 						for (ArrayList<Piece> p : board) {
@@ -131,8 +133,11 @@ public class Server extends Thread {
 						System.out.println("move is legal");
 						for (ObjectOutputStream o : outPipes) {
 							try {
-
-								o.writeObject(new Message(board.clone()));
+								ArrayList<Piece>[] boardToSend = new ArrayList[24];
+								for (int j = 0; j < 24; j++) {
+								    boardToSend[j] = new ArrayList<Piece>(board[j]); // Copy each ArrayList
+								}
+								o.writeObject(new Message(boardToSend));
 								o.flush();
 								System.out.println("Board sent");
 							} catch (IOException e) {


### PR DESCRIPTION
The `Server` class was using a shallow copy of the board state when sending board states after successful moves to `Client`s, which meant it did not include changes. The `move` method was modified to perform a deep copy, resolving this issue.